### PR TITLE
Implement real /v1/models endpoint fetching from Yupp AI

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -238,16 +238,47 @@ async def yupp_bridge_exception_handler(request: Request, exc: YuppBridgeExcepti
 
 @app.get("/v1/models", response_model=ModelList)
 async def list_models(request: Request):
-    """List available models."""
+    """List available models from Yupp AI."""
     require_api_key(request)
     
-    # Return available models
-    # In a real implementation, this would fetch from Yupp AI
-    models = [
-        ModelInfo(id="gpt-4o", object="model", created=1700000000, owned_by="openai"),
-        ModelInfo(id="claude-3-5-sonnet", object="model", created=1700000000, owned_by="anthropic"),
-        ModelInfo(id="gemini-1.5-pro", object="model", created=1700000000, owned_by="google"),
-    ]
+    # Get account for making authenticated requests
+    try:
+        account = await auth.get_best_yupp_account()
+        if not account:
+            raise NoValidAccountException("No valid Yupp account available")
+    except Exception as e:
+        logger.error(f"Failed to get account: {e}")
+        raise NoValidAccountException("No valid Yupp account available")
+    
+    # Get config for proxy
+    cfg = get_config()
+    proxy = cfg.get("proxy")
+    
+    # Fetch models from Yupp AI
+    try:
+        yupp_models = await transport.fetch_yupp_models(account=account, proxy=proxy)
+    except Exception as e:
+        logger.error(f"Failed to fetch models from Yupp AI: {e}")
+        # Fallback to empty list if fetch fails
+        yupp_models = []
+    
+    # Convert to ModelInfo format
+    models = []
+    for m in yupp_models:
+        models.append(ModelInfo(
+            id=m.get("id", ""),
+            object="model",
+            created=m.get("created", 1700000000),
+            owned_by=m.get("owned_by", "yupp"),
+        ))
+    
+    # If no models fetched, return fallback
+    if not models:
+        models = [
+            ModelInfo(id="gpt-4o", object="model", created=1700000000, owned_by="openai"),
+            ModelInfo(id="claude-3-5-sonnet", object="model", created=1700000000, owned_by="anthropic"),
+            ModelInfo(id="gemini-1.5-pro", object="model", created=1700000000, owned_by="google"),
+        ]
     
     return ModelList(object="list", data=models)
 

--- a/src/transport.py
+++ b/src/transport.py
@@ -454,3 +454,79 @@ async def sync_record_feedback(
     except Exception as e:
         log_debug(f"Failed to record feedback: {e}")
         return None
+
+
+async def fetch_yupp_models(
+    account: Dict[str, Any],
+    proxy: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """
+    Fetch available models from Yupp AI.
+    
+    Returns a list of model dictionaries with id, name, and metadata.
+    """
+    scraper = create_scraper()
+    
+    if proxy:
+        scraper.proxies = {"http": proxy, "https": proxy}
+    
+    # Set auth cookie
+    scraper.cookies.set(constants.SESSION_TOKEN_COOKIE, account["token"])
+    
+    # Build the trpc request URL
+    url = f"{constants.YUPP_BASE_URL}/api/trpc/model.getModelInfoList?scribble.getScribbleByLabel"
+    
+    # trpc batch payload for model info
+    payload = [
+        {
+            "json": {
+                "isFetchScribble": False,
+            }
+        }
+    ]
+    
+    try:
+        response = scraper.post(
+            url,
+            json=payload,
+            headers={
+                "Content-Type": "application/json",
+            },
+            timeout=constants.DEFAULT_TIMEOUT,
+        )
+        response.raise_for_status()
+        
+        data = response.json()
+        log_debug(f"Models response: {data}")
+        
+        models = []
+        
+        # Parse trpc response format
+        # The response is an array with result objects containing data.json
+        if isinstance(data, list):
+            for item in data:
+                result = item.get("result", {})
+                json_data = result.get("data", {}).get("json", {})
+                
+                # Extract models from the response
+                # Yupp AI returns models in different formats
+                model_list = json_data if isinstance(json_data, list) else json_data.get("models", [])
+                
+                for model in model_list:
+                    model_id = model.get("modelName") or model.get("id") or model.get("name", "")
+                    if model_id:
+                        models.append({
+                            "id": model_id,
+                            "name": model.get("displayName") or model.get("name", model_id),
+                            "object": "model",
+                            "created": model.get("createdAt", 1700000000),
+                            "owned_by": model.get("owner", "yupp"),
+                            "description": model.get("description", ""),
+                            "tags": model.get("tags", []),
+                        })
+        
+        return models
+        
+    except Exception as e:
+        log_debug(f"Failed to fetch models: {e}")
+        return []


### PR DESCRIPTION
## Summary
- Implements real `/v1/models` endpoint that fetches available models from Yupp AI's API instead of returning hardcoded mock data
- Adds `fetch_yupp_models()` function in `transport.py` that calls the Yupp AI trpc endpoint (`/api/trpc/model.getModelInfoList`)
- Updates the endpoint in `main.py` to use the new function with proper error handling and fallback to default models if the API call fails

## Changes
- `src/transport.py`: Added `fetch_yupp_models()` async function
- `src/main.py`: Updated `/v1/models` endpoint to fetch from Yupp AI